### PR TITLE
feat(domain): add OAuth2 models and contracts

### DIFF
--- a/blog_api/Domain/contracts/repositories/oauth_repository.go
+++ b/blog_api/Domain/contracts/repositories/oauth_repository.go
@@ -1,0 +1,12 @@
+ package repositories
+
+import "blog_api/Domain/models"
+
+
+type IOAuthRepository interface {
+	CreateOAuthUser(oauthUser *models.OAuthUser) error
+	GetOAuthUserByProviderID(provider, providerID string) (*models.OAuthUser, error)
+	GetOAuthUserByEmail(provider, email string) (*models.OAuthUser, error)
+	UpdateOAuthUser(oauthUser *models.OAuthUser) error
+	LinkOAuthToUser(oauthUserID, userID string) error
+}

--- a/blog_api/Domain/contracts/services/oauth_service.go
+++ b/blog_api/Domain/contracts/services/oauth_service.go
@@ -1,0 +1,11 @@
+package services
+
+import "blog_api/Domain/models"
+
+
+type IOAuthService interface {
+    GetAuthURL(state string) (string, error)
+    ExchangeCodeForToken(code string) (*models.OAuthToken, error)
+    GetUserInfo(accessToken string) (*models.OAuthUserInfo, error)
+    GetProviderName() string
+}

--- a/blog_api/Domain/contracts/usecases/oauth_usecase.go
+++ b/blog_api/Domain/contracts/usecases/oauth_usecase.go
@@ -1,0 +1,10 @@
+package usecases
+
+import "blog_api/Domain/models"
+
+
+type IOAuthUseCase interface {
+	InitiateOAuthFlow(provider string) (string, error)
+	HandleOAuthCallback(provider, code, state string) (*models.OAuthLoginResult, error)
+	LinkOAuthToExistingUser(provider, code, userID string) error
+}

--- a/blog_api/Domain/models/oauth.go
+++ b/blog_api/Domain/models/oauth.go
@@ -1,0 +1,50 @@
+package models
+
+import "time"
+
+// OAuth access token
+type OAuthToken struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    int
+	TokenType    string
+}
+
+//user information from OAuth provider
+type OAuthUserInfo struct {
+	ProviderID string
+	Email      string
+	Name       string
+	Picture    string
+}
+
+// an OAuth user account linked to a platform user
+type OAuthUser struct {
+	ID           string
+	UserID       string 
+	Provider     string // "google", "github", "facebook"
+	ProviderID   string // ID from the provider 
+	Email        string
+	Name         string
+	Picture      string
+	AccessToken  string
+	RefreshToken string
+	ExpiresAt    *time.Time
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// represents the result of an OAuth login
+type OAuthLoginResult struct {
+	User         *User
+	AccessToken  string
+	RefreshToken string
+	IsNewUser    bool
+}
+
+// OAuthProvider constants
+const (
+	ProviderGoogle   = "google"
+	ProviderGitHub   = "github"
+	ProviderFacebook = "facebook"
+)


### PR DESCRIPTION
- add oauth models (token, user info, oauth user, login result)
- add interfaces for oauth service, usecase, and repository
- add provider names (google, github, facebook)
